### PR TITLE
Updated return type for bug severity

### DIFF
--- a/AIAgents.Laboratory.API/Controllers/v1/PluginsController.cs
+++ b/AIAgents.Laboratory.API/Controllers/v1/PluginsController.cs
@@ -91,7 +91,7 @@ public class PluginsController(IPluginsHandler pluginsHandler) : BaseController
 	/// <param name="bugSeverityInput">The bug severity input.</param>
 	/// <returns>The bug severity ai response dto.</returns>
 	[HttpPost(RouteConstants.Plugins.GetBugSeverity_Route)]
-	[ProducesResponseType(typeof(BugSeverityResponseDTO), StatusCodes.Status200OK)]
+	[ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
 	[ProducesResponseType(StatusCodes.Status401Unauthorized)]
 	[ProducesResponseType(StatusCodes.Status400BadRequest)]
 	[ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -99,7 +99,7 @@ public class PluginsController(IPluginsHandler pluginsHandler) : BaseController
 	public async Task<ResponseDTO> GetBugSeverityAsync([FromBody] BugSeverityInputDTO bugSeverityInput)
 	{
 		var result = await pluginsHandler.GetBugSeverityAsync(bugSeverityInput).ConfigureAwait(false);
-		if (!string.IsNullOrEmpty(result.BugSeverity))
+		if (!string.IsNullOrEmpty(result))
 		{
 			return HandleSuccessRequestResponse(result);
 		}

--- a/Adapters/AIAgents.Laboratory.API.Adapters/Contracts/IPluginsHandler.cs
+++ b/Adapters/AIAgents.Laboratory.API.Adapters/Contracts/IPluginsHandler.cs
@@ -8,31 +8,31 @@ namespace AIAgents.Laboratory.API.Adapters.Contracts;
 /// </summary>
 public interface IPluginsHandler
 {
-    /// <summary>
-    /// Rewrites text async.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>The rewrite response dto.</returns>
-    Task<RewriteResponseDTO> RewriteTextAsync(string story);
+	/// <summary>
+	/// Rewrites text async.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>The rewrite response dto.</returns>
+	Task<RewriteResponseDTO> RewriteTextAsync(string story);
 
-    /// <summary>
-    /// Generates the tag for story asynchronous.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>The genre tag response dto.</returns>
-    Task<TagResponseDTO> GenerateTagForStoryAsync(string story);
+	/// <summary>
+	/// Generates the tag for story asynchronous.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>The genre tag response dto.</returns>
+	Task<TagResponseDTO> GenerateTagForStoryAsync(string story);
 
-    /// <summary>
-    /// Moderates the content data asynchronous.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>The moderation content response dto.</returns>
-    Task<ModerationContentResponseDTO> ModerateContentDataAsync(string story);
+	/// <summary>
+	/// Moderates the content data asynchronous.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>The moderation content response dto.</returns>
+	Task<ModerationContentResponseDTO> ModerateContentDataAsync(string story);
 
-    /// <summary>
-    /// Gets the bug severity asynchronous.
-    /// </summary>
-    /// <param name="bugSeverityInput">The bug severity input.</param>
-    /// <returns>The bug severity response.</returns>
-    Task<BugSeverityResponseDTO> GetBugSeverityAsync(BugSeverityInputDTO bugSeverityInput);
+	/// <summary>
+	/// Gets the bug severity asynchronous.
+	/// </summary>
+	/// <param name="bugSeverityInput">The bug severity input.</param>
+	/// <returns>The bug severity response.</returns>
+	Task<string> GetBugSeverityAsync(BugSeverityInputDTO bugSeverityInput);
 }

--- a/Adapters/AIAgents.Laboratory.API.Adapters/Handlers/PluginsHandler.cs
+++ b/Adapters/AIAgents.Laboratory.API.Adapters/Handlers/PluginsHandler.cs
@@ -15,7 +15,7 @@ namespace AIAgents.Laboratory.API.Adapters.Handlers;
 /// <seealso cref="IPluginsHandler"/>
 public class PluginsHandler(IMapper mapper, IPluginsAiServices pluginsAiServices) : IPluginsHandler
 {
-    /// <summary>
+	/// <summary>
 	/// Generates the tag for story asynchronous.
 	/// </summary>
 	/// <param name="story">The story.</param>
@@ -23,48 +23,47 @@ public class PluginsHandler(IMapper mapper, IPluginsAiServices pluginsAiServices
 	/// The genre tag response dto.
 	/// </returns>
 	public async Task<TagResponseDTO> GenerateTagForStoryAsync(string story)
-    {
-        var response = await pluginsAiServices.GenerateTagForStoryAsync(story).ConfigureAwait(false);
-        return mapper.Map<TagResponseDTO>(response);
-    }
+	{
+		var response = await pluginsAiServices.GenerateTagForStoryAsync(story).ConfigureAwait(false);
+		return mapper.Map<TagResponseDTO>(response);
+	}
 
-    /// <summary>
+	/// <summary>
 	/// Gets the bug severity asynchronous.
 	/// </summary>
 	/// <param name="bugSeverityInput">The bug severity input.</param>
 	/// <returns>
 	/// The bug severity response.
 	/// </returns>
-	public async Task<BugSeverityResponseDTO> GetBugSeverityAsync(BugSeverityInputDTO bugSeverityInput)
-    {
-        var domainInput = mapper.Map<BugSeverityInput>(bugSeverityInput);
-        var domainResult = await pluginsAiServices.GetBugSeverityAsync(domainInput).ConfigureAwait(false);
-        return mapper.Map<BugSeverityResponseDTO>(domainResult);
-    }
+	public async Task<string> GetBugSeverityAsync(BugSeverityInputDTO bugSeverityInput)
+	{
+		var domainInput = mapper.Map<BugSeverityInput>(bugSeverityInput);
+		return await pluginsAiServices.GetBugSeverityAsync(domainInput).ConfigureAwait(false);
+	}
 
-    /// <summary>
-    /// Moderates the content data asynchronous.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>
-    /// The moderation content response dto.
-    /// </returns>
-    public async Task<ModerationContentResponseDTO> ModerateContentDataAsync(string story)
-    {
-        var response = await pluginsAiServices.ModerateContentDataAsync(story).ConfigureAwait(false);
-        return mapper.Map<ModerationContentResponseDTO>(response);
-    }
+	/// <summary>
+	/// Moderates the content data asynchronous.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>
+	/// The moderation content response dto.
+	/// </returns>
+	public async Task<ModerationContentResponseDTO> ModerateContentDataAsync(string story)
+	{
+		var response = await pluginsAiServices.ModerateContentDataAsync(story).ConfigureAwait(false);
+		return mapper.Map<ModerationContentResponseDTO>(response);
+	}
 
-    /// <summary>
-    /// Rewrites text async.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>
-    /// The rewrite response dto.
-    /// </returns>
-    public async Task<RewriteResponseDTO> RewriteTextAsync(string story)
-    {
-        var response = await pluginsAiServices.RewriteTextAsync(story).ConfigureAwait(false);
-        return mapper.Map<RewriteResponseDTO>(response);
-    }
+	/// <summary>
+	/// Rewrites text async.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>
+	/// The rewrite response dto.
+	/// </returns>
+	public async Task<RewriteResponseDTO> RewriteTextAsync(string story)
+	{
+		var response = await pluginsAiServices.RewriteTextAsync(story).ConfigureAwait(false);
+		return mapper.Map<RewriteResponseDTO>(response);
+	}
 }

--- a/Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/AIServices/AgentServices.cs
+++ b/Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/AIServices/AgentServices.cs
@@ -1,19 +1,12 @@
-// *********************************************************************************
-//	<copyright file="AgentServices.cs" company="Personal">
-//		Copyright (c) 2025 Personal
-//	</copyright>
-// <summary>The Agent Services Class.</summary>
-// *********************************************************************************
-
+using System.Globalization;
+using System.Text.Json;
+using AIAgents.Laboratory.Domain.DomainEntities;
 using AIAgents.Laboratory.Domain.DrivenPorts;
+using AIAgents.Laboratory.Domain.Helpers;
 using AIAgents.Laboratory.SemanticKernel.Adapters.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
-using System.Globalization;
-using System.Text.Json;
-using AIAgents.Laboratory.Domain.Helpers;
 using static AIAgents.Laboratory.SemanticKernel.Adapters.Helpers.Constants;
-using AIAgents.Laboratory.Domain.DomainEntities;
 
 namespace AIAgents.Laboratory.SemanticKernel.Adapters.AIServices;
 
@@ -44,7 +37,7 @@ public class AgentServices(ILogger<AgentServices> logger, Kernel kernel) : IAIAg
 			{
 				throw new Exception(ExceptionConstants.SomethingWentWrongMessage);
 			}
-			
+
 			var normalizedIntent = userIntent.Trim().ToUpperInvariant();
 			var aiResponse = normalizedIntent switch
 			{

--- a/Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/Plugins/UtilityPlugins.cs
+++ b/Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/Plugins/UtilityPlugins.cs
@@ -1,15 +1,6 @@
-﻿// *********************************************************************************
-//	<copyright file="UtilityPlugins.cs" company="Personal">
-//		Copyright (c) 2025 Personal
-//	</copyright>
-// <summary>The Utility Plugins.</summary>
-// *********************************************************************************
-
-using AIAgents.Laboratory.Domain.DomainEntities;
-using AIAgents.Laboratory.SemanticKernel.Adapters.Helpers;
+﻿using AIAgents.Laboratory.SemanticKernel.Adapters.Helpers;
 using Microsoft.SemanticKernel;
 using System.ComponentModel;
-using System.Text.Json;
 using static AIAgents.Laboratory.Domain.Helpers.PluginHelpers.UtilityPlugins;
 
 namespace AIAgents.Laboratory.SemanticKernel.Adapters.Plugins;
@@ -31,18 +22,10 @@ public class UtilityPlugins
 	{
 		var arguments = new KernelArguments()
 		{{
-				Constants.ArgumentsConstants.KernelArgumentsInputConstant, input
+			Constants.ArgumentsConstants.KernelArgumentsInputConstant, input
 		}};
 
 		var result = await kernel.InvokePromptAsync(DetermineBugSeverityFunction.FunctionInstructions, arguments).ConfigureAwait(false);
-		var aiMetadata = result.Metadata;
-
-		return JsonSerializer.Serialize(new BugSeverityResponse
-		{
-			BugSeverity = result.GetValue<string>() ?? string.Empty,
-			TotalTokensConsumed = Convert.ToInt32(aiMetadata?[Constants.ArgumentsConstants.TotalTokenCountConstant] ?? 0),
-			CandidatesTokenCount = Convert.ToInt32(aiMetadata?[Constants.ArgumentsConstants.CandidatesTokenCountConstant] ?? 0),
-			PromptTokenCount = Convert.ToInt32(aiMetadata?[Constants.ArgumentsConstants.PromptTokenCountConstant] ?? 0)
-		});
+		return result.GetValue<string>() ?? string.Empty;
 	}
 }

--- a/Core/AIAgents.Laboratory.Domain/DrivingPorts/IPluginsAiServices.cs
+++ b/Core/AIAgents.Laboratory.Domain/DrivingPorts/IPluginsAiServices.cs
@@ -33,5 +33,5 @@ public interface IPluginsAiServices
     /// </summary>
     /// <param name="bugSeverityInput">The bug severity input.</param>
     /// <returns>The bug severity response.</returns>
-    Task<BugSeverityResponse> GetBugSeverityAsync(BugSeverityInput bugSeverityInput);
+    Task<string> GetBugSeverityAsync(BugSeverityInput bugSeverityInput);
 }

--- a/Core/AIAgents.Laboratory.Domain/UseCases/PluginsAiServices.cs
+++ b/Core/AIAgents.Laboratory.Domain/UseCases/PluginsAiServices.cs
@@ -18,46 +18,37 @@ namespace AIAgents.Laboratory.Domain.UseCases;
 /// <param name="commonAiService">The common ai services.</param>
 public class PluginsAiServices(ILogger<PluginsAiServices> logger, IAIAgentServices aiAgentServices, ICommonAiService commonAiService) : IPluginsAiServices
 {
-    /// <summary>
+	/// <summary>
 	/// Gets the bug severity asynchronous.
 	/// </summary>
 	/// <param name="bugSeverityInput">The bug severity input.</param>
 	/// <returns>
 	/// The bug severity response.
 	/// </returns>
-	public async Task<BugSeverityResponse> GetBugSeverityAsync(BugSeverityInput bugSeverityInput)
-    {
-        try
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(GetBugSeverityAsync), DateTime.UtcNow, string.Empty));
-            if (bugSeverityInput is null)
-            {
-                var exception = new Exception(ExceptionConstants.InputParametersCannotBeEmptyMessage);
-                logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GetBugSeverityAsync), DateTime.UtcNow, exception.Message));
-                throw exception;
-            }
+	public async Task<string> GetBugSeverityAsync(BugSeverityInput bugSeverityInput)
+	{
+		try
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(GetBugSeverityAsync), DateTime.UtcNow, string.Empty));
+			if (string.IsNullOrEmpty(bugSeverityInput.BugTitle) || string.IsNullOrEmpty(bugSeverityInput.BugDescription))
+			{
+				throw new Exception(ExceptionConstants.InputParametersCannotBeEmptyMessage);
+			}
 
-            var response = await aiAgentServices.GetAiFunctionResponseAsync(bugSeverityInput, PluginHelpers.UtilityPlugins.PluginName, PluginHelpers.UtilityPlugins.DetermineBugSeverityFunction.FunctionName).ConfigureAwait(false);
-            var bugSeverityResponse = JsonSerializer.Deserialize<BugSeverityResponse>(response);
-            if (bugSeverityResponse is not null)
-            {
-                bugSeverityResponse.ModelUsed = commonAiService.GetCurrentModelId();
-            }
+			return await aiAgentServices.GetAiFunctionResponseAsync(bugSeverityInput, PluginHelpers.UtilityPlugins.PluginName, PluginHelpers.UtilityPlugins.DetermineBugSeverityFunction.FunctionName).ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GetBugSeverityAsync), DateTime.UtcNow, ex.Message));
+			throw;
+		}
+		finally
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(GetBugSeverityAsync), DateTime.UtcNow, string.Empty));
+		}
+	}
 
-            return bugSeverityResponse ?? new BugSeverityResponse { ModelUsed = commonAiService.GetCurrentModelId() };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GetBugSeverityAsync), DateTime.UtcNow, ex.Message));
-            throw;
-        }
-        finally
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(GetBugSeverityAsync), DateTime.UtcNow, string.Empty));
-        }
-    }
-
-    /// <summary>
+	/// <summary>
 	/// Generates the tag for story asynchronous.
 	/// </summary>
 	/// <param name="story">The story.</param>
@@ -65,112 +56,112 @@ public class PluginsAiServices(ILogger<PluginsAiServices> logger, IAIAgentServic
 	/// The genre tag response dto.
 	/// </returns>
 	public async Task<TagResponse> GenerateTagForStoryAsync(string story)
-    {
-        try
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, string.Empty));
-            if (string.IsNullOrEmpty(story))
-            {
-                var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
-                logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, exception.Message));
-                throw exception;
-            }
+	{
+		try
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, string.Empty));
+			if (string.IsNullOrEmpty(story))
+			{
+				var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
+				logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, exception.Message));
+				throw exception;
+			}
 
-            var response = await aiAgentServices.GetAiFunctionResponseAsync(story, ContentPlugins.PluginName, ContentPlugins.GenerateGenreTagForStoryFunction.FunctionName).ConfigureAwait(false);
-            var tagResponse = JsonSerializer.Deserialize<TagResponse>(response);
-            if (tagResponse is not null)
-            {
-                tagResponse.ModelUsed = commonAiService.GetCurrentModelId();
-            }
+			var response = await aiAgentServices.GetAiFunctionResponseAsync(story, ContentPlugins.PluginName, ContentPlugins.GenerateGenreTagForStoryFunction.FunctionName).ConfigureAwait(false);
+			var tagResponse = JsonSerializer.Deserialize<TagResponse>(response);
+			if (tagResponse is not null)
+			{
+				tagResponse.ModelUsed = commonAiService.GetCurrentModelId();
+			}
 
-            return tagResponse ?? new TagResponse { ModelUsed = commonAiService.GetCurrentModelId() };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, ex.Message));
-            throw;
-        }
-        finally
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, string.Empty));
-        }
-    }
+			return tagResponse ?? new TagResponse { ModelUsed = commonAiService.GetCurrentModelId() };
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, ex.Message));
+			throw;
+		}
+		finally
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(GenerateTagForStoryAsync), DateTime.UtcNow, string.Empty));
+		}
+	}
 
-    /// <summary>
-    /// Moderates the content data asynchronous.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>
-    /// The moderation content response dto.
-    /// </returns>
-    public async Task<ModerationContentResponse> ModerateContentDataAsync(string story)
-    {
-        try
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(ModerateContentDataAsync), DateTime.UtcNow, string.Empty));
-            if (string.IsNullOrEmpty(story))
-            {
-                var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
-                logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(ModerateContentDataAsync), DateTime.UtcNow, exception.Message));
-                throw exception;
-            }
+	/// <summary>
+	/// Moderates the content data asynchronous.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>
+	/// The moderation content response dto.
+	/// </returns>
+	public async Task<ModerationContentResponse> ModerateContentDataAsync(string story)
+	{
+		try
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(ModerateContentDataAsync), DateTime.UtcNow, string.Empty));
+			if (string.IsNullOrEmpty(story))
+			{
+				var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
+				logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(ModerateContentDataAsync), DateTime.UtcNow, exception.Message));
+				throw exception;
+			}
 
-            var response = await aiAgentServices.GetAiFunctionResponseAsync(story, ContentPlugins.PluginName, ContentPlugins.ContentModerationFunction.FunctionName).ConfigureAwait(false);
-            var moderationResponse = JsonSerializer.Deserialize<ModerationContentResponse>(response);
-            if (moderationResponse is not null)
-            {
-                moderationResponse.ModelUsed = commonAiService.GetCurrentModelId();
-            }
+			var response = await aiAgentServices.GetAiFunctionResponseAsync(story, ContentPlugins.PluginName, ContentPlugins.ContentModerationFunction.FunctionName).ConfigureAwait(false);
+			var moderationResponse = JsonSerializer.Deserialize<ModerationContentResponse>(response);
+			if (moderationResponse is not null)
+			{
+				moderationResponse.ModelUsed = commonAiService.GetCurrentModelId();
+			}
 
-            return moderationResponse ?? new ModerationContentResponse { ModelUsed = commonAiService.GetCurrentModelId() };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(ModerateContentDataAsync), DateTime.UtcNow, ex.Message, string.Empty));
-            throw;
-        }
-        finally
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(ModerateContentDataAsync), DateTime.UtcNow));
-        }
-    }
+			return moderationResponse ?? new ModerationContentResponse { ModelUsed = commonAiService.GetCurrentModelId() };
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(ModerateContentDataAsync), DateTime.UtcNow, ex.Message, string.Empty));
+			throw;
+		}
+		finally
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(ModerateContentDataAsync), DateTime.UtcNow));
+		}
+	}
 
-    /// <summary>
-    /// Rewrites text async.
-    /// </summary>
-    /// <param name="story">The story.</param>
-    /// <returns>
-    /// The rewrite response dto.
-    /// </returns>
-    public async Task<RewriteResponse> RewriteTextAsync(string story)
-    {
-        try
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(RewriteTextAsync), DateTime.UtcNow, string.Empty));
-            if (string.IsNullOrEmpty(story))
-            {
-                var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
-                logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(RewriteTextAsync), DateTime.UtcNow, exception.Message));
-                throw exception;
-            }
+	/// <summary>
+	/// Rewrites text async.
+	/// </summary>
+	/// <param name="story">The story.</param>
+	/// <returns>
+	/// The rewrite response dto.
+	/// </returns>
+	public async Task<RewriteResponse> RewriteTextAsync(string story)
+	{
+		try
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodStart, nameof(RewriteTextAsync), DateTime.UtcNow, string.Empty));
+			if (string.IsNullOrEmpty(story))
+			{
+				var exception = new Exception(ExceptionConstants.StoryCannotBeEmptyMessage);
+				logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(RewriteTextAsync), DateTime.UtcNow, exception.Message));
+				throw exception;
+			}
 
-            var response = await aiAgentServices.GetAiFunctionResponseAsync(story, RewriteTextPlugin.PluginName, RewriteTextPlugin.RewriteUserStoryFunction.FunctionName).ConfigureAwait(false);
-            var rewriteResponse = JsonSerializer.Deserialize<RewriteResponse>(response);
-            if (rewriteResponse is not null)
-            {
-                rewriteResponse.ModelUsed = commonAiService.GetCurrentModelId();
-            }
+			var response = await aiAgentServices.GetAiFunctionResponseAsync(story, RewriteTextPlugin.PluginName, RewriteTextPlugin.RewriteUserStoryFunction.FunctionName).ConfigureAwait(false);
+			var rewriteResponse = JsonSerializer.Deserialize<RewriteResponse>(response);
+			if (rewriteResponse is not null)
+			{
+				rewriteResponse.ModelUsed = commonAiService.GetCurrentModelId();
+			}
 
-            return rewriteResponse ?? new RewriteResponse { ModelUsed = commonAiService.GetCurrentModelId() };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(RewriteTextAsync), DateTime.UtcNow, ex.Message));
-            throw;
-        }
-        finally
-        {
-            logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(RewriteTextAsync), DateTime.UtcNow, string.Empty));
-        }
-    }
+			return rewriteResponse ?? new RewriteResponse { ModelUsed = commonAiService.GetCurrentModelId() };
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodFailed, nameof(RewriteTextAsync), DateTime.UtcNow, ex.Message));
+			throw;
+		}
+		finally
+		{
+			logger.LogInformation(string.Format(CultureInfo.CurrentCulture, LoggingConstants.LogHelperMethodEnd, nameof(RewriteTextAsync), DateTime.UtcNow, string.Empty));
+		}
+	}
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Changed bug severity return type from complex object to string

- Simplified API response handling for bug severity endpoint

- Removed JSON serialization/deserialization for bug severity

- Updated code formatting to use tabs consistently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BugSeverityResponseDTO"] --> B["string"]
  C["JSON Serialization"] --> D["Direct String Return"]
  E["Complex Response"] --> F["Simple String Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PluginsController.cs</strong><dd><code>Update controller response type to string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AIAgents.Laboratory.API/Controllers/v1/PluginsController.cs

<ul><li>Updated <code>ProducesResponseType</code> from <code>BugSeverityResponseDTO</code> to <code>string</code><br> <li> Changed result validation to check string directly instead of <br><code>BugSeverity</code> property</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-bebbd87817dcd5327bf73128f85a1b1ff33469f9aad03e653c6de904febf8487">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IPluginsHandler.cs</strong><dd><code>Update interface return type to string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adapters/AIAgents.Laboratory.API.Adapters/Contracts/IPluginsHandler.cs

<ul><li>Changed return type from <code>BugSeverityResponseDTO</code> to <code>string</code> for <br><code>GetBugSeverityAsync</code><br> <li> Applied consistent tab formatting throughout file</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-ed8718116c0890f9b73657d874e2680f1cb6a3ca0f13a95d22da8b517e92ddfc">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PluginsHandler.cs</strong><dd><code>Simplify handler to return string directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adapters/AIAgents.Laboratory.API.Adapters/Handlers/PluginsHandler.cs

<ul><li>Simplified <code>GetBugSeverityAsync</code> to return string directly from AI <br>service<br> <li> Removed mapper usage for bug severity response<br> <li> Applied consistent tab formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-cf8139bcc7e46896e809196bfecefd61535806ec20991bf61cb21a089c295992">+35/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UtilityPlugins.cs</strong><dd><code>Simplify plugin to return raw string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/Plugins/UtilityPlugins.cs

<ul><li>Removed copyright header and unused imports<br> <li> Simplified <code>DetermineBugSeverityAsync</code> to return string directly<br> <li> Removed JSON serialization of <code>BugSeverityResponse</code> object</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-0c88151fb2a14bce1a16346fe86d01a3f1185edf39e8962193de9039d0058f75">+3/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IPluginsAiServices.cs</strong><dd><code>Update domain interface return type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Core/AIAgents.Laboratory.Domain/DrivingPorts/IPluginsAiServices.cs

<ul><li>Changed return type from <code>BugSeverityResponse</code> to <code>string</code> for <br><code>GetBugSeverityAsync</code></ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-501f0e2ec51a3ead2554f9db32322180455839e6ec0d4ade5b5db773dc711c13">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PluginsAiServices.cs</strong><dd><code>Simplify use case to return string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Core/AIAgents.Laboratory.Domain/UseCases/PluginsAiServices.cs

<ul><li>Simplified <code>GetBugSeverityAsync</code> to return string directly from AI agent<br> <li> Removed JSON deserialization and complex response object creation<br> <li> Updated input validation to check specific properties<br> <li> Applied consistent tab formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-db4fc0c84f07df63fedfdb89004c10bd4ec7fc0812815c423a155b8529dbff76">+123/-132</a></td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AgentServices.cs</strong><dd><code>Clean up imports and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Adapters/AIAgents.Laboratory.SemanticKernel.Adapters/AIServices/AgentServices.cs

<ul><li>Removed copyright header and reorganized imports<br> <li> Minor whitespace formatting changes</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/22/files#diff-fc7fca4dbde3821cdd5b0d9bd838f0d71a0819f6281ffa08578f9741ac9db483">+5/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

