### PR TITLE
Added db build + deploy in CI CD

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -3,6 +3,7 @@ name: Build and Deploy AI Agents Laboratory
 env:
     API_PROJECT_PATH: AIAgents.Laboratory.API/AIAgents.Laboratory.API.csproj
     UI_PROJECT_PATH: AIAgents.Laboratory.UI
+    DATABASE_PROJECT_PATH: AIAgents.Laboratory.Database/AIAgents.Laboratory.Database.sqlproj
 
 on:
     workflow_dispatch:
@@ -15,6 +16,12 @@ on:
 
             deploy_ui:
                 description: "AIAgents.Laboratory.UI"
+                required: false
+                default: true
+                type: boolean
+
+            deploy_db:
+                description: "AIAgents.Laboratory.Database"
                 required: false
                 default: true
                 type: boolean
@@ -102,3 +109,70 @@ jobs:
                   action: "upload"
                   app_location: ${{ env.UI_PROJECT_PATH }}
                   output_location: "out"
+
+    build-database:
+        name: Build AIAgents.Laboratory.Database
+        runs-on: windows-latest
+        if: ${{ inputs.deploy_db }}
+        outputs:
+            artifact_path: ${{ steps.set-artifact-path.outputs.path }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Setup .NET 10
+              uses: actions/setup-dotnet@v3
+              with:
+                  dotnet-version: "10.0.x"
+
+            - name: Install dependencies and build DB solution
+              run: |
+                  dotnet restore ${{ env.DATABASE_PROJECT_PATH }}
+                  dotnet build ${{ env.DATABASE_PROJECT_PATH }} --configuration Release --no-restore
+
+            - name: Publish the dacpac file
+              run: |
+                  dotnet publish ${{ env.DATABASE_PROJECT_PATH }} --configuration Release --output ./publish-db
+
+            - name: Set datbase objects artifact path
+              id: set-artifact-path
+              run: echo "path=./publish-db" >> $GITHUB_OUTPUT
+
+            - name: Upload Database Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: db-artifact
+                  path: ./publish-db
+
+    deploy-database:
+        name: Deploy AIAgents.Laboratory.Database
+        runs-on: windows-latest
+        needs: build-database
+        environment: Production
+        permissions:
+            id-token: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Azure Login
+              uses: azure/login@v2
+              with:
+                  client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+            - name: Download database artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: db-artifact
+                  path: ./publish-db
+
+            - name: Deploy to Azure SQL Database
+              uses: azure/sql-action@v2.3
+              with:
+                  connection-string: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+                  path: "./publish-db/AIAgents.Laboratory.Database.dacpac"
+                  action: "publish"
+                  arguments: "/p:DropObjectsNotInSource=true /p:BlockOnPossibleDataLoss=false /p:IgnoreUserSettingsObjects=true /p:IgnoreLoginSids=true /p:IgnorePermissions=true /p:IgnoreRoleMembership=true"


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **PR Type**
Enhancement


___

### **Description**
- Add database build and deploy jobs to CI/CD pipeline

- Introduce `deploy_db` workflow input for database deployment control

- Build database project and publish dacpac artifact on Windows runner

- Deploy dacpac to Azure SQL Database with configurable merge options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Dispatch"] -->|deploy_db input| B["Build Database Job"]
  B -->|windows-latest| C["Restore & Build .sqlproj"]
  C -->|Publish| D["Generate dacpac Artifact"]
  D -->|needs: build-database| E["Deploy Database Job"]
  E -->|Azure Login| F["Deploy to Azure SQL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-azure.yml</strong><dd><code>Add database build and deploy workflow jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-azure.yml

<ul><li>Added <code>DATABASE_PROJECT_PATH</code> environment variable for database project <br>reference<br> <li> Added <code>deploy_db</code> workflow input parameter with default true value<br> <li> Created new <code>build-database</code> job that restores, builds, and publishes <br>the .sqlproj file<br> <li> Created new <code>deploy-database</code> job that authenticates to Azure and <br>deploys dacpac with merge options</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/38/files#diff-56b627681480cc223d2268d21e78ec786dc3824bc4ba8f288a413d340407997a">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).