### PR TITLE
Downmerge for CI CD

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -34,7 +34,7 @@ jobs:
     build-api:
         name: Build API solution
         runs-on: ubuntu-latest
-        if: ${{ inputs.deploy_api }}
+        if: ${{ github.event_name == 'push' || inputs.deploy_api }}
         outputs:
             artifact_path: ${{ steps.set-artifact-path.outputs.path }}
         steps:
@@ -87,7 +87,7 @@ jobs:
 
     build-and-deploy-web:
         name: Build and Deploy UI solution
-        if: ${{ inputs.deploy_ui }}
+        if: ${{ github.event_name == 'push' || inputs.deploy_ui }}
         runs-on: ubuntu-latest
         environment: Production
 
@@ -117,7 +117,7 @@ jobs:
     build-database:
         name: Build Database project
         runs-on: windows-latest
-        if: ${{ inputs.deploy_db }}
+        if: ${{ github.event_name == 'push' || inputs.deploy_db }}
         outputs:
             artifact_path: ${{ steps.set-artifact-path.outputs.path }}
 


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **PR Type**
Enhancement


___

### **Description**
- Updated CI/CD pipeline conditions to trigger on push events

- Modified build job conditions to include automatic push triggers

- Ensures API, UI, and database builds run on direct pushes

- Maintains manual input override capability for selective deployments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push Event"] --> B["Trigger Condition"]
  C["Manual Input"] --> B
  B --> D["Build API"]
  B --> E["Build UI"]
  B --> F["Build Database"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-azure.yml</strong><dd><code>Add push event triggers to deployment jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-azure.yml

<ul><li>Modified <code>build-api</code> job condition from <code>inputs.deploy_api</code> to <br><code>github.event_name == 'push' || inputs.deploy_api</code><br> <li> Modified <code>build-and-deploy-web</code> job condition from <code>inputs.deploy_ui</code> to <br><code>github.event_name == 'push' || inputs.deploy_ui</code><br> <li> Modified <code>build-database</code> job condition from <code>inputs.deploy_db</code> to <br><code>github.event_name == 'push' || inputs.deploy_db</code><br> <li> Enables automatic deployment on push events while preserving manual <br>workflow dispatch capability</ul>


</details>


  </td>
  <td><a href="https://github.com/debanjanpaul10/ai-agents-laboratory/pull/45/files#diff-56b627681480cc223d2268d21e78ec786dc3824bc4ba8f288a413d340407997a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).